### PR TITLE
Use newer AWS SDK that correctly handles buckets in different regions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <kuali.compile.source>1.5</kuali.compile.source>
     <kuali.compile.target>1.5</kuali.compile.target>
     <slf4j.version>1.6.4</slf4j.version>
-    <aws.version>1.3.22</aws.version>
+    <aws.version>1.4.2</aws.version>
     <spring.version>3.1.2.RELEASE</spring.version>
     <kuali-s3.version>1.0.1</kuali-s3.version>
   </properties>


### PR DESCRIPTION
Right now, the plugin dies horribly if your bucket is in an unexpected region.

This is what's happening (via curl):

```
> GET /BUCKET-NAME HTTP/1.1
> User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8r zlib/1.2.5
> Host: s3.amazonaws.com
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< x-amz-request-id: D75BAD9E2517644B
< x-amz-id-2: drlAYrg34WM1pgL2sRZE7VHLNqdXV7JUHx9QOD5BY+V2DRugkaJE4RBiOPGOHvHx
< Content-Type: application/xml
< Transfer-Encoding: chunked
< Date: Thu, 18 Apr 2013 20:15:24 GMT
< Server: AmazonS3
<
<?xml version="1.0" encoding="UTF-8"?>
* Connection #0 to host s3.amazonaws.com left intact
<Error><Code>PermanentRedirect</Code><Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message><RequestId>D75BAD9E2517644B</RequestId><Bucket>BUCKET-NAME</Bucket><HostId>drlAYrg34WM1pgL2sRZE7VHLNqdXV7JUHx9QOD5BY+V2DRugkaJE4RBiOPGOHvHx</HostId><Endpoint>BUCKET-NAME.s3.amazonaws.com</Endpoint></Error>
```

The older version of the AWS SDK does not correctly handle this response, so the upload fails with:

```
Could not connect to repository: Unable to execute HTTP request: null: ClientProtocolException: Received redirect response HTTP/1.1 301 Moved Permanently but no location header
```

Switching to use an up-to-date version of the SDK solves this.
