### PR TITLE
added support for auth profiles defined in ~/.aws/credentials file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <project.scm.vendor>git</project.scm.vendor>
     <project.java.version>1.5</project.java.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <aws.version>1.6.4</aws.version>
+    <aws.version>1.9.16</aws.version>
     <spring.version>3.2.5.RELEASE</spring.version>
     <kuali-s3.version>1.0.1</kuali-s3.version>
     <junit.version>4.11</junit.version>

--- a/src/main/java/org/kuali/maven/wagon/S3Wagon.java
+++ b/src/main/java/org/kuali/maven/wagon/S3Wagon.java
@@ -501,8 +501,8 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 	}
 
 	/**
-	 * Create AWSCredentionals from the information in system properties, environment variables, settings.xml, or EC2 instance metadata (only applicable when running the wagon on
-	 * an Amazon EC2 instance)
+	 * Create AWSCredentionals from the information in system properties, environment variables, settings.xml,
+	 * ~/.aws/credentials, or EC2 instance metadata (only applicable when running the wagon on an Amazon EC2 instance)
 	 */
 	protected AWSCredentials getCredentials(final Repository source, final AuthenticationInfo authenticationInfo) {
 		Optional<AuthenticationInfo> auth = Optional.fromNullable(authenticationInfo);

--- a/src/main/java/org/kuali/maven/wagon/S3Wagon.java
+++ b/src/main/java/org/kuali/maven/wagon/S3Wagon.java
@@ -189,8 +189,7 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 
 	@Override
 	protected void connectToRepository(Repository source, AuthenticationInfo auth, ProxyInfo proxy) {
-
-		AWSCredentials credentials = getCredentials(auth);
+		AWSCredentials credentials = getCredentials(source, auth);
 		this.client = getAmazonS3Client(credentials);
 		this.transferManager = new TransferManager(credentials);
 		this.bucketName = source.getHost();
@@ -505,9 +504,9 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 	 * Create AWSCredentionals from the information in system properties, environment variables, settings.xml, or EC2 instance metadata (only applicable when running the wagon on
 	 * an Amazon EC2 instance)
 	 */
-	protected AWSCredentials getCredentials(final AuthenticationInfo authenticationInfo) {
+	protected AWSCredentials getCredentials(final Repository source, final AuthenticationInfo authenticationInfo) {
 		Optional<AuthenticationInfo> auth = Optional.fromNullable(authenticationInfo);
-		AWSCredentialsProviderChain chain = new MavenAwsCredentialsProviderChain(auth);
+		AWSCredentialsProviderChain chain = new MavenAwsCredentialsProviderChain(source, auth);
 		AWSCredentials credentials = chain.getCredentials();
 		if (credentials instanceof AWSSessionCredentials) {
 			return new AwsSessionCredentials((AWSSessionCredentials) credentials);

--- a/src/main/java/org/kuali/maven/wagon/auth/MavenAwsCredentialsProviderChain.java
+++ b/src/main/java/org/kuali/maven/wagon/auth/MavenAwsCredentialsProviderChain.java
@@ -18,6 +18,7 @@ package org.kuali.maven.wagon.auth;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -26,17 +27,18 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.google.common.base.Optional;
+import org.apache.maven.wagon.repository.Repository;
 
 /**
  * This chain searches for AWS credentials in system properties -> environment variables -> ~/.m2/settings.xml -> Amazon's EC2 Instance Metadata Service
  */
 public final class MavenAwsCredentialsProviderChain extends AWSCredentialsProviderChain {
 
-	public MavenAwsCredentialsProviderChain(Optional<AuthenticationInfo> auth) {
-		super(getProviders(auth));
+	public MavenAwsCredentialsProviderChain(Repository source, Optional<AuthenticationInfo> auth) {
+		super(getProviders(source, auth));
 	}
 
-	private static AWSCredentialsProvider[] getProviders(Optional<AuthenticationInfo> auth) {
+	private static AWSCredentialsProvider[] getProviders(Repository source, Optional<AuthenticationInfo> auth) {
 		List<AWSCredentialsProvider> providers = new ArrayList<AWSCredentialsProvider>();
 
 		// System properties always win
@@ -47,6 +49,14 @@ public final class MavenAwsCredentialsProviderChain extends AWSCredentialsProvid
 
 		// Then fall through to settings.xml
 		providers.add(new AuthenticationInfoCredentialsProvider(auth));
+
+		// Then fall through to a ProfileCredentialsProvider that looks for a credentials profile
+		// using the repository id
+		providers.add(new ProfileCredentialsProvider(source.getId()));
+
+		// Then fall through to a ProfileCredentialsProvider that uses the AWS_PROFILE env variable
+		// or the default profile, if it is defined
+		providers.add(new ProfileCredentialsProvider());
 
 		// Then fall through to Amazon's EC2 Instance Metadata Service
 		// http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-roles.html

--- a/src/main/java/org/kuali/maven/wagon/auth/MavenAwsCredentialsProviderChain.java
+++ b/src/main/java/org/kuali/maven/wagon/auth/MavenAwsCredentialsProviderChain.java
@@ -30,7 +30,7 @@ import com.google.common.base.Optional;
 import org.apache.maven.wagon.repository.Repository;
 
 /**
- * This chain searches for AWS credentials in system properties -> environment variables -> ~/.m2/settings.xml -> Amazon's EC2 Instance Metadata Service
+ * This chain searches for AWS credentials in system properties -> environment variables -> ~/.m2/settings.xml -> ~/.aws/credentials -> Amazon's EC2 Instance Metadata Service
  */
 public final class MavenAwsCredentialsProviderChain extends AWSCredentialsProviderChain {
 


### PR DESCRIPTION
Now, after checking the auth info from settings.xml, the provider chain will then check for credentials in 2 new ways before trying the IAM instance profile: 

1. use the source repository id to look up a specific AWS profile from ~/.aws/credentials (created using the cli command ```aws configure```).

2. look for a profile in the same manner as above, using the value of the ```AWS_PROFILE``` environment variable if it is set, or otherwise look for a profile named ```default```.

I upgraded the AWS SDK dependencies to the latest version (1.9.16) in order enable this support