### PR TITLE
Fix issue with setting ACL

### DIFF
--- a/src/main/java/org/kuali/maven/wagon/S3Wagon.java
+++ b/src/main/java/org/kuali/maven/wagon/S3Wagon.java
@@ -99,7 +99,6 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 	public static final int DEFAULT_MAX_THREAD_COUNT = 50;
 	public static final int DEFAULT_DIVISOR = 50;
 	public static final int DEFAULT_READ_TIMEOUT = 60 * 1000;
-	public static final CannedAccessControlList DEFAULT_ACL = CannedAccessControlList.PublicRead;
 	private static final File TEMP_DIR = getCanonicalFile(System.getProperty("java.io.tmpdir"));
 	private static final String TEMP_DIR_PATH = TEMP_DIR.getAbsolutePath();
 
@@ -111,7 +110,7 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 	String protocol = getValue(PROTOCOL_KEY, HTTPS);
 	boolean http = HTTP.equals(protocol);
 	int readTimeout = DEFAULT_READ_TIMEOUT;
-	CannedAccessControlList acl = DEFAULT_ACL;
+	CannedAccessControlList acl = null;
 	TransferManager transferManager;
 
 	private static final Logger log = LoggerFactory.getLogger(S3Wagon.class);
@@ -388,7 +387,9 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 			InputStream input = getInputStream(source, progress);
 			ObjectMetadata metadata = getObjectMetadata(source, destination);
 			PutObjectRequest request = new PutObjectRequest(bucketName, key, input, metadata);
-			request.setCannedAcl(acl);
+            if (acl != null) {
+                request.setCannedAcl(acl);
+            }
 			return request;
 		} catch (FileNotFoundException e) {
 			throw new AmazonServiceException("File not found", e);


### PR DESCRIPTION
By default, maven-s3-wagon set the ACL to publicRead. This isn't desired behaviors if you happen to be using private S3 buckets
- If you don't explicitly set a default, the ACL is automatically set depending on the bucket's ACL (this is the desired behaviour for working with ACL). This means if you don't specify an ACL in `settings.xml`, you shouldn't even be making the `request.setCannedAcl` call
- Setting the default to publicRead means you get permission errors if you are trying to use maven-s3-wagon unless you explicitly give the required permission to the S3 user
- Setting the default ACL to publicRead also makes no sense for a private repository (repository is private for a reason!)
