### PR TITLE
Update the AWS SDK for Java to 1.11.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <project.scm.vendor>git</project.scm.vendor>
     <project.java.version>1.5</project.java.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <aws.version>1.6.4</aws.version>
+    <aws.version>1.11.41</aws.version>
     <spring.version>3.2.5.RELEASE</spring.version>
     <kuali-s3.version>1.0.1</kuali-s3.version>
     <junit.version>4.11</junit.version>
@@ -102,10 +102,16 @@
       <groupId>org.kuali.common</groupId>
       <artifactId>kuali-s3</artifactId>
       <version>${kuali-s3.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
+      <artifactId>aws-java-sdk-s3</artifactId>
       <version>${aws.version}</version>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
While there: only depend on aws-sdk-java-s3, so that downloading
dependencies is a lot faster and the plugin is smaller.
