### PR TITLE
Enhanced security for private S3 repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
-
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <groupId>org.kuali.maven.wagons</groupId>
   <artifactId>maven-s3-wagon</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.2.3-SNAPSHOT</version>
   <name>Maven S3 Wagon</name>
   <inceptionYear>2010</inceptionYear>
   <description>

--- a/src/test/java/org/kuali/maven/wagon/S3WagonTest.java
+++ b/src/test/java/org/kuali/maven/wagon/S3WagonTest.java
@@ -15,16 +15,16 @@
  */
 package org.kuali.maven.wagon;
 
-import java.util.List;
-
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.repository.Repository;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.List;
+
 public class S3WagonTest {
-	private static final String USERNAME = "AKIAJFD5IM7IPVVUEBNA";
-	private static final String PASSWORD = System.getProperty("secret.key");
+	private static final String USERNAME = System.getProperty("AWS_ACCESS_KEY_ID");
+	private static final String PASSWORD = System.getProperty("AWS_SECRET_ACCESS_KEY");
 
 	// private static final Logger log = LoggerFactory.getLogger(S3WagonTest.class);
 


### PR DESCRIPTION
- Defaulted bucket permissions to
CannedAccessControlList.AuthenticatedRead.
- Added support for S3 server-side encryption. On connect, S3Wagon
  attempts to detect if your bucket requires SSE by uploading a file
without requesting SSE. If this request fails, the we assume that
the policy requires SSE and use it for all future PutObjectRequests.